### PR TITLE
Exclude airbyte ns from gatekeeper resources checks

### DIFF
--- a/helm/gatekeeper-constraints/chart/templates/container_limits.yaml
+++ b/helm/gatekeeper-constraints/chart/templates/container_limits.yaml
@@ -15,6 +15,7 @@ spec:
     - velero
     - cattle-system
     - ingress-nginx
+    - airbyte
   parameters:
     cpu: "{{ .Values.limits.cpu }}"
     memory: "{{ .Values.limits.memory }}"

--- a/helm/gatekeeper-constraints/chart/templates/container_requests.yaml
+++ b/helm/gatekeeper-constraints/chart/templates/container_requests.yaml
@@ -15,6 +15,7 @@ spec:
     - velero
     - cattle-system
     - ingress-nginx
+    - airbyte
   parameters:
     cpu: "{{ .Values.requests.cpu }}"
     memory: "{{ .Values.requests.memory }}"


### PR DESCRIPTION
Worker pods instantiated by airbyte contains multiple containers. While all these containers have resources (both requests and limits) defined, one of them conflicts with the constraints imposed by gatekeeper:

![image](https://github.com/onlineque/internal-eks-cluster/assets/10287868/4aa9e057-06af-48f2-b0cd-d08d0fd70c2d)

Because of these values the creation of the pod is rejected: 

![image](https://github.com/onlineque/internal-eks-cluster/assets/10287868/77f2a9e3-86dd-4077-8dc8-8ba0e80c0b81)

Unfortunately it is currently not possible to configure these resources definitions through the helm chart.

This PR excludes the airbyte ns from the checks on resources executed by gatekeeper to allow the pods to be created by airbyte.