### PR TITLE
Add client_max_body_size to nginx config to support Airbyte heavy posts

### DIFF
--- a/templates/nginx-ingress.yaml.tmpl
+++ b/templates/nginx-ingress.yaml.tmpl
@@ -7,6 +7,7 @@ controller:
   config:
     ssl-redirect: "false" # we use `special` port to control ssl redirection
     server-snippet: |
+      client_max_body_size 50M;
       listen 8000;
       if ( $server_port = 80 ) {
         return 308 https://$host$request_uri;


### PR DESCRIPTION
Creation of connections in Airbyte can fail if the source system contains many tables. It fails if the body of the HTTP POST request executed upon creation of the connection is bigger than what is allowed by nginx. 

This PR increases the size of the body that a client application can send.
