### PR TITLE
Add metricDenylist for kube-state-metrics

### DIFF
--- a/helm/kube-prometheus-stack/template/values.yaml.tmpl
+++ b/helm/kube-prometheus-stack/template/values.yaml.tmpl
@@ -81,3 +81,7 @@ prometheus-node-exporter:
               operator: NotIn
               values:
                 - fargate
+
+kube-state-metrics:
+  metricDenylist
+    - kube_job_.*


### PR DESCRIPTION
Added `kube_job_.*` related metrics to the deny list for kube-state-metrics.